### PR TITLE
Remove stray stack trace causing syntax error

### DIFF
--- a/app.py
+++ b/app.py
@@ -578,11 +578,6 @@ def render_prompt_source_diag():
 # render_prompt_source_diag()
 # ===== [04C] END ====================================================
 
-File "/mount/src/maic/app.py", line 645
-      except Exception as e:
-      ^
-SyntaxError: invalid syntax
-
 # ===== [05B] TAG DIAGNOSTICS (NEW) — START ==================================
 def render_tag_diagnostics():
     """


### PR DESCRIPTION
## Summary
- clean up `app.py` by removing an accidentally committed stack trace
- this resolves a SyntaxError that prevented the application from running

## Testing
- `python -m py_compile app.py`
- `pytest`
- `ruff check app.py` *(fails: found 68 existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3fe312bc8321963989b8826d8060